### PR TITLE
[PMK-3262] Opts for custom api server flags, scheduler flags, and controller manager flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ master_vip_ipv4             (string)    Virtual IP for master nodes
 master_vip_iface            (string)    Interface to attach master VIP to
 enable_metal_lb             (boolean)   Enable/disable MetalLB
 metallb_cidr                (string)    MetalLB CIDR
+api_server_flags            (list)      List of custom api server flags. Example: ["--request-timeout=2m0s", "--kubelet-timeout=20s"]
+scheduler_flags             (list)      List of scheduler flags. Example: ["--kube-api-burst=120"]
+controller_manager_flags    (list)      List of controller manager flags. Example: ["--large-cluster-size-threshold=60"]
 ```
 
 ## Issues

--- a/pf9/provider.go
+++ b/pf9/provider.go
@@ -56,6 +56,9 @@ type Qbert struct {
 	MasterVIPIface    string                 `json:"masterVipIface,omitempty"`
 	EnableMetalLB     bool                   `json:"enableMetallb,omitempty"`
 	MetalLBCIDR       string                 `json:"metallbCidr,omitempty"`
+	ApiServerFlags    []string               `json:"apiServerFlags, omitempty"`
+	SchedulerFlags    []string               `json:"schedulerFlags, omitempty"`
+	CtrlrManagerFlags []string               `json:"controllerManagerFlags, omitempty"`
 }
 
 // Config stores the PF9 provider configuration options

--- a/pf9/resource_pf9_cluster.go
+++ b/pf9/resource_pf9_cluster.go
@@ -236,6 +236,27 @@ func resourcePF9Cluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"api_server_flags": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+				        Type: schema.TypeString,
+				},      
+				Optional: true,
+			},      
+			"scheduler_flags": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+				        Type: schema.TypeString,
+				},      
+				Optional: true,
+			},      
+			"controller_manager_flags": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+				        Type: schema.TypeString,
+				},      
+				Optional: true,
+			}, 
 		},
 	}
 }
@@ -261,6 +282,9 @@ func resourcePF9ClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	zones := convertIntfListToString(d.Get("zones").([]interface{}))
 	PrivateSubnets := convertIntfListToString(d.Get("private_subnets").([]interface{}))
 	Subnets := convertIntfListToString(d.Get("subnets").([]interface{}))
+	ApiServerFlags := convertIntfListToString(d.Get("api_server_flags").([]interface{}))
+	SchedulerFlags := convertIntfListToString(d.Get("scheduler_flags").([]interface{}))
+	CtrlrManagerFlags := convertIntfListToString(d.Get("controller_manager_flags").([]interface{}))
 
 	request := &Qbert{
 		WorkloadsOnMaster: d.Get("allow_workloads_on_master").(int),
@@ -308,6 +332,9 @@ func resourcePF9ClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		MasterVIPIface:    d.Get("master_vip_iface").(string),
 		EnableMetalLB:     d.Get("enable_metal_lb").(bool),
 		MetalLBCIDR:       d.Get("metallb_cidr").(string),
+		ApiServerFlags:    ApiServerFlags,
+		SchedulerFlags:    SchedulerFlags,
+		CtrlrManagerFlags: CtrlrManagerFlags,
 	}
 
 	requestData, errJSON := json.Marshal(request)
@@ -407,6 +434,9 @@ func resourcePF9ClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("master_vip_iface", cluster.MasterVIPIface)
 	d.Set("enable_metal_lb", strconv.FormatBool(cluster.EnableMetalLB))
 	d.Set("metallb_cidr", cluster.MetalLBCIDR)
+	d.Set("api_server_flags", "["+strings.Join(cluster.ApiServerFlags, ",")+"]")
+	d.Set("scheduler_flags", "["+strings.Join(cluster.SchedulerFlags, ",")+"]")
+	d.Set("controller_manager_flags", "["+strings.Join(cluster.CtrlrManagerFlags, ",")+"]")
 
 	return nil
 }


### PR DESCRIPTION
[PMK-3262] Added opts for custom api server flags per the jira, as well as scheduler flags and controller manager flags opts. Readme also updated with examples of new flag opts. 

[PMK-3262]: https://platform9.atlassian.net/browse/PMK-3262