### PR TITLE
Remove use_pf9_domain, masterless. Drop omitempty for domainId, externalDNSName, and serviceFqdn. Small fix. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ calico_ip_ip_mode           (string)    IP-IP mode if using the calico network p
 calico_nat_outgoing         (boolean)   Enable outgoing NAT for calico nodes (default: True)
 cloud_provider_uuid         (string)    Cloud provider UUID
 private_subnets             (list)      List of private subnets to use
-privileged                  (int)       Allow/disallow privileged containers (0/1)    
+privileged                  (int)       Allow/disallow privileged containers (0/1)
 region                      (string)    AWS region
 location                    (string)    Azure region
 runtime_config              (string)    Runtime config data

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ worker_sku                  (string)    Flavor of worker nodes (Azure)
 num_masters                 (string)    Number of masters. Recommended: 1, 3, or 5.
 num_workers                 (string)    Number of workers.
 enable_cas                  (boolean)   Enable or disable cluster auto scaler.
-masterless                  (int)       Run masterless (0/1) (for advanced users)    
 network_plugin              (string)    Network plugin to use: Available options: flannel, calico, canal(experimental)
 calico_ip_ip_mode           (string)    IP-IP mode if using the calico network plugin. Available options: Always, Never, CrossSubnet (default: Always)
 calico_nat_outgoing         (boolean)   Enable outgoing NAT for calico nodes (default: True)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ zones                       (list)      List of Azure availability zones. Exampl
 containers_cidr             (string)    Subnet used for Pod IPs
 service_cidr                (string)    Subnet used for Service IPs
 domain_id                   (string)    AWS Domain ID
-external_dns_name           (string)    "auto-generate", or provide DNS name
+external_dns_name           (string)    provide DNS name
 http_proxy                  (string)    (optional) Specify the HTTP proxy for this cluster. Format: <scheme>://<username>:<password>@<host>:<port>
 internal_elb                (boolean)   Enable or disable elastic load balancer
 is_private                  (boolean)   Private cluster (for advanced users only)
@@ -102,11 +102,10 @@ privileged                  (int)       Allow/disallow privileged containers (0/
 region                      (string)    AWS region
 location                    (string)    Azure region
 runtime_config              (string)    Runtime config data
-service_fqdn                (string)    "auto-generate" or provide FQDN for service endpoints
+service_fqdn                (string)    provide FQDN for service endpoints
 ssh_key                     (string)    Keyname for SSH access to nodes
 subnets                     (list)      List of subnets to use (advanced)
 tags                        (map)       Tags to apply on nodes (key-value pairs)
-use_pf9_domain              (boolean)   Use platform9 domains for FQDNs
 vpc                         (string)    Name of AWS VPC for nodes
 master_vip_ipv4             (string)    Virtual IP for master nodes
 master_vip_iface            (string)    Interface to attach master VIP to

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -60,7 +60,6 @@ worker_sku                  (string)    Flavor of worker nodes (Azure)
 num_masters                 (string)    Number of masters. Recommended: 1, 3, or 5.
 num_workers                 (string)    Number of workers.
 enable_cas                  (boolean)   Enable or disable cluster auto scaler.
-masterless                  (int)       Run masterless (0/1) (for advanced users)    
 network_plugin              (string)    Network plugin to use: Available options: flannel, calico, canal(experimental)
 calico_ip_ip_mode           (string)    IP-IP mode if using the calico network plugin. Available options: Always, Never, CrossSubnet (default: Always)
 calico_nat_outgoing         (boolean)   Enable outgoing NAT for calico nodes (default: True)
@@ -74,7 +73,6 @@ service_fqdn                (string)    "auto-generate" or provide FQDN for serv
 ssh_key                     (string)    Keyname for SSH access to nodes
 subnets                     (list)      List of subnets to use (advanced)
 tags                        (map)       Tags to apply on nodes (key-value pairs)
-use_pf9_domain              (boolean)   Use platform9 domains for FQDNs
 vpc                         (string)    Name of AWS VPC for nodes
 master_vip_ipv4             (string)    Virtual IP for master nodes
 master_vip_iface            (string)    Interface to attach master VIP to

--- a/main.tf
+++ b/main.tf
@@ -36,5 +36,4 @@ resource "pf9_cluster" "cluster_1" {
     num_masters = 1
     num_workers = 3
     enable_cas = "false"
-    masterless = 1
 }

--- a/main.tf
+++ b/main.tf
@@ -25,14 +25,13 @@ resource "pf9_cluster" "cluster_1" {
     master_flavor = "t2.medium"
     name = "tf-sample-1"
     network_plugin = "flannel"
-    node_pool_uuid = "5c703dc1-6037-44a6-b7f4-1d7fc89cbca6"
+    cloud_provider_uuid = "5c703dc1-6037-44a6-b7f4-1d7fc89cbca6"
     privileged = 1
     region = "us-west-2"
     runtime_config = ""
     service_fqdn = "auto-generate"
     services_cidr = "10.21.0.0/16"
     ssh_key = "my-ssh-key"
-    use_pf9_domain = "true"
     worker_flavor = "t2.medium"
     num_masters = 1
     num_workers = 3

--- a/main.tf
+++ b/main.tf
@@ -7,31 +7,26 @@ resource "pf9_aws_cloud_provider" "sample_aws_prov" {
 }
 
 resource "pf9_cluster" "cluster_1" {
-    project_uuid = "5738c9a8269a42788c96d160047b5b1b"
+    project_uuid = "<UUID>"
+    cloud_provider_uuid = "<UUID>"
     allow_workloads_on_master = 0
     ami = "ubuntu"
     app_catalog_enabled = 0
-    azs = [
-        "us-west-2a",
-        "us-west-2b",
-        "us-west-2c",
-        "us-west-2d"
-    ]
+    azs = ["us-west-2b"]
     containers_cidr = "10.20.0.0/16"
-    domain_id = "/hostedzone/DOMAINID"
-    external_dns_name = "auto-generate"
+    domain_id = ""
+    external_dns_name = ""
     internal_elb = false
     is_private = "false"
     master_flavor = "t2.medium"
-    name = "tf-sample-1"
+    name = "cluster_1"
     network_plugin = "flannel"
-    cloud_provider_uuid = "5c703dc1-6037-44a6-b7f4-1d7fc89cbca6"
     privileged = 1
     region = "us-west-2"
     runtime_config = ""
-    service_fqdn = "auto-generate"
+    service_fqdn = ""
     services_cidr = "10.21.0.0/16"
-    ssh_key = "my-ssh-key"
+    ssh_key = "sample-ssh-key"
     worker_flavor = "t2.medium"
     num_masters = 1
     num_workers = 3

--- a/pf9/provider.go
+++ b/pf9/provider.go
@@ -17,8 +17,8 @@ type Qbert struct {
 	Azs               []string               `json:"azs,omitempty"`
         Zones             []string               `json:"zones,omitempty"`
 	ContainersCIDR    string                 `json:"containersCidr,omitempty"`
-	DomainID          string                 `json:"domainId,omitempty"`
-	ExternalDNSName   string                 `json:"externalDnsName,omitempty"`
+	DomainID          string                 `json:"domainId"`
+	ExternalDNSName   string                 `json:"externalDnsName"`
 	HTTPProxy         string                 `json:"httpProxy,omitempty"`
 	InternalElb       bool                   `json:"internalElb,omitempty"`
 	IsPrivate         bool                   `json:"isPrivate,omitempty"`
@@ -43,12 +43,11 @@ type Qbert struct {
 	Region            string                 `json:"region,omitempty"`
         Location          string                 `json:"location,omitempty"`
 	RuntimeConfig     string                 `json:"runtimeConfig,omitempty"`
-	ServiceFQDN       string                 `json:"serviceFqdn,omitempty"`
+	ServiceFQDN       string                 `json:"serviceFqdn"`
 	ServicesCIDR      string                 `json:"servicesCidr,omitempty"`
 	SSHKey            string                 `json:"sshKey,omitempty"`
 	Subnets           []string               `json:"subnets,omitempty"`
 	Tags              map[string]interface{} `json:"tags,omitempty"`
-	UsePF9Domain      bool                   `json:"usePf9Domain,omitempty"`
 	VPC               string                 `json:"vpc,omitempty"`
 	WorkerFlavor      string                 `json:"workerFlavor,omitempty"`
         WorkerSku         string                 `json:"workerSku,omitempty"`

--- a/pf9/provider.go
+++ b/pf9/provider.go
@@ -37,7 +37,6 @@ type Qbert struct {
 	NumMaxSpotWorkers int                    `json:"numMaxSpotWorkers,omitempty"`
 	SpotPrice         float64                `json:"spotPrice,omitempty"`
 	SpotWorkerFlavor  string                 `json:"spotWorkerFlavor,omitempty"`
-	Masterless        int                    `json:"masterless,omitempty"`
 	PrivateSubnets    []string               `json:"privateSubnets,omitempty"`
 	Privileged        int                    `json:"privileged,omitempty"`
 	Region            string                 `json:"region,omitempty"`

--- a/pf9/resource_pf9_cluster.go
+++ b/pf9/resource_pf9_cluster.go
@@ -134,10 +134,6 @@ func resourcePF9Cluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"masterless": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -355,7 +351,6 @@ func resourcePF9ClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		NumMaxSpotWorkers: d.Get("num_max_spot_workers").(int),
 		SpotPrice:         d.Get("spot_price").(float64),
 		SpotWorkerFlavor:  d.Get("spot_worker_flavor").(string),
-		Masterless:        d.Get("masterless").(int),
 		PrivateSubnets:    PrivateSubnets,
 		Privileged:        d.Get("privileged").(int),
 		Region:            d.Get("region").(string),
@@ -455,7 +450,6 @@ func resourcePF9ClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("num_max_spot_workers", fmt.Sprint(cluster.NumMaxSpotWorkers))
 	d.Set("spot_price", fmt.Sprintf("%f", cluster.SpotPrice))
 	d.Set("spot_worker_flavor", cluster.SpotWorkerFlavor)
-	d.Set("masterless", fmt.Sprint(cluster.Masterless))
 	d.Set("private_subnets", "["+strings.Join(cluster.PrivateSubnets, ",")+"]")
 	d.Set("privileged", fmt.Sprint(cluster.Privileged))
 	d.Set("region", cluster.Region)

--- a/pf9/resource_pf9_cluster.go
+++ b/pf9/resource_pf9_cluster.go
@@ -209,10 +209,6 @@ func resourcePF9Cluster() *schema.Resource {
 				},
 				Optional: true,
 			},
-			"use_pf9_domain": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
 			"vpc": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -370,7 +366,6 @@ func resourcePF9ClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		SSHKey:            d.Get("ssh_key").(string),
 		Subnets:           Subnets,
 		Tags:              d.Get("tags").(map[string]interface{}),
-		UsePF9Domain:      d.Get("use_pf9_domain").(bool),
 		VPC:               d.Get("vpc").(string),
 		WorkerFlavor:      d.Get("worker_flavor").(string),
 		WorkerSku:         d.Get("worker_sku").(string),
@@ -471,7 +466,6 @@ func resourcePF9ClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ssh_key", cluster.SSHKey)
 	d.Set("subnets", "["+strings.Join(cluster.Subnets, ",")+"]")
 	d.Set("tags", fmt.Sprintf("%v", cluster.Tags))
-	d.Set("use_pf9_domain", strconv.FormatBool(cluster.UsePF9Domain))
 	d.Set("vpc", cluster.VPC)
 	d.Set("worker_flavor", cluster.WorkerFlavor)
 	d.Set("worker_sku", cluster.WorkerSku)


### PR DESCRIPTION
remove use_pf9_domain and masterless altogether and have domainId, externalDNSName, and serviceFqdn default to empty. Change node_pool_uuid to cloud_provider_uuid in example.