### PR TITLE
Skip addon delete while deleting cluster to avoid nodes going to not ready state

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -941,12 +941,6 @@ func (r *clusterResource) Delete(ctx context.Context, req resource.DeleteRequest
 	projectID := authInfo.ProjectID
 	clusterID := data.Id.ValueString()
 
-	tflog.Debug(ctx, "Deleting cluster addons", map[string]interface{}{"clusterID": clusterID})
-	err = r.client.Qbert().DeleteAllClusterAddons(ctx, clusterID)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to delete cluster addons", err.Error())
-		return
-	}
 	tflog.Debug(ctx, "Deleting cluster", map[string]interface{}{"clusterID": clusterID})
 	err = r.client.Qbert().DeleteCluster(clusterID, projectID)
 	if err != nil {


### PR DESCRIPTION
While testing the destroy operation, noticed that the nodes go into converging state and cannot be reused for creation clusters again. It appears the addon delete operation is interfering with the delete operation. Also, explicit delete of addons is not needed as they get deleted automatically on cluster deletion.