### PR TITLE
Prevent terraform from failing when ApiServerFlags are set

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -1586,6 +1586,10 @@ func createCreateClusterRequest(ctx context.Context, clusterModel *resource_clus
 			return createClusterReq, diags
 		}
 		createClusterReq.CloudProperties = cloudProperties
+		// It looks like the cloudProperties field is getting embedded under
+		// another cloudProperties field causing terraform to complain about inconsitency
+		// This fix prevents that. We might have to relook at the whole cloudProperties section later
+		createClusterReq.ApiServerFlags = cloudProperties.APIServerFlags
 	}
 
 	createClusterReq.EtcdBackup, diags = getEtcdBackupConfig(ctx, clusterModel.EtcdBackup)


### PR DESCRIPTION
When terraform file provides api server flags in the following format, terraform complains as shown below.
```
  k8s_config = {
    api_server_flags          = var.api_server_flags
    controller_manager_flags  = []
    scheduler_flags           = []
    api_server_runtime_config = null
  }
```

```
        Error: Provider produced inconsistent result after apply
        │
        │ When applying changes to pf9_cluster.mgmt, provider "provider[\"registry.terraform.io/platform9/pf9\"]" produced an unexpected new value: .k8s_config: was
        │ cty.ObjectVal(map[string]cty.Value{"api_server_flags":cty.ListVal([]cty.Value{cty.StringVal("--oidc-issuer-url=https://kaapi-qa.us.auth0.com/"),
        │ cty.StringVal("--oidc-client-id=K32pBE0j8g7MKL5nmhFHqdha2gVpIDOM"), cty.StringVal("--oidc-groups-claim=org_id"), cty.StringVal("--sinu=great")}),
        │ "api_server_runtime_config":cty.NullVal(cty.String), "controller_manager_flags":cty.ListValEmpty(cty.String), "scheduler_flags":cty.ListValEmpty(cty.String)}),
        │ but now null.
        │
        │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```


Also, the cluster object has the cloudProperties nested twice.
```
        "cloudProperties": {
            "domainId": "",
            "monitoring": "{}",
            "masterNodes": "[\"0632c73f-ad51-40f6-85c9-c5c7c851940b\"]",
            "workerNodes": "[\"4ac4c23a-3323-49f4-b722-d9fd5f69fe4b\"]",
            "cloudProperties": "{\"apiServerFlags\":\"[\\\"--oidc-issuer-url=https://kaapi-qa.us.auth0.com/\\\",\\\"--oidc-client-id=K32pBE0j8g7MKL5nmhFHqdha2gVpIDOM\\\",\\\"--oidc-groups-claim=org_id\\\",\\\"--sinu=great\\\"]\",\"controllerManagerFlags\":\"[]\",\"schedulerFlags\":\"[]\"}",
            "apiServerFlags": ""
        },
```


After the fix the apiServerFlags is shown at the correct level.
```
        "cloudProperties": {
            "domainId": "",
            "monitoring": "{}",
            "masterNodes": "[\"0632c73f-ad51-40f6-85c9-c5c7c851940b\"]",
            "workerNodes": "[\"4ac4c23a-3323-49f4-b722-d9fd5f69fe4b\"]",
            "cloudProperties": "{\"apiServerFlags\":\"[\\\"--oidc-issuer-url=https://kaapi-qa.us.auth0.com/\\\",\\\"--oidc-client-id=K32pBE0j8g7MKL5nmhFHqdha2gVpIDOM\\\",\\\"--oidc-groups-claim=org_id\\\",\\\"--sinu=great\\\"]\",\"controllerManagerFlags\":\"[]\",\"schedulerFlags\":\"[]\"}",
            "apiServerFlags": "[\"--oidc-issuer-url=https://kaapi-qa.us.auth0.com/\",\"--oidc-client-id=K32pBE0j8g7MKL5nmhFHqdha2gVpIDOM\",\"--oidc-groups-claim=org_id\",\"--sinu=great\"]"
        },
```